### PR TITLE
Fix compile for X11 and add gentoo config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,38 @@
 
 # Debug files
 *.dSYM/
+
+# Build generated files
+makefile
+bin/*
+!bin/README
+lib/buildlib
+lib/buildshared
+lib/makefile
+include/makefile
+include/rle_config.h
+man/makefile
+tools/makefile
+get/qcr/makefile
+get/gmr27/makefile
+tools/makefile
+tools/clock/makefile
+get/getx11/makefile
+get/cx3d/makefile
+get/makefile
+cnv/tex/makefile
+cnv/rletogif/makefile
+cnv/rletoabAB62/makefile
+cnv/makefile
+# Install generated files
+man/install*
+get/install*
+get/getx11/install*
+lib/install
+include/install
+tools/install*
+cnv/rletogif/install*
+cnv/install*
+man-dest/man1/*
+man-dest/man3/*
+man-dest/man5/*

--- a/cnv/giftorle.c
+++ b/cnv/giftorle.c
@@ -203,7 +203,7 @@ FILE	*fd;
 	    EasyFail("EOF in extention\n",TRUE);
 	if (c == 0)
 	    return FALSE;
-	if (read(fd,buf,(int) c)!=(int) c)
+	if (!ReadOK(fd,buf,(int) c))
 	    EasyFail("EOF in extention\n",TRUE);
     }
 }

--- a/cnv/rlatorle.c
+++ b/cnv/rlatorle.c
@@ -162,7 +162,7 @@ int *height;
        }
    VPRINTF(stderr, "Channel color space %s\n", head.rla_head.chan);
    if ( rlb_flag )
-       VPRINTF(stderr, "Interlaced?         %s\n", head.rlb_head.filter_type);
+       VPRINTF(stderr, "Interlaced?         %hd\n", head.rlb_head.filter_type);
    else
        VPRINTF(stderr, "Interlaced?         %s\n", "-unused-");
    if (do_matte)

--- a/cnv/rletops.c
+++ b/cnv/rletops.c
@@ -231,7 +231,7 @@ puthexpix(outfile,p)
 FILE *outfile;
 unsigned char p;
 {
-    static npixo = 0;
+    static int npixo = 0;
     static char tohex[] = "0123456789ABCDEF";
 
     putc(tohex[(p>>4)&0xF],outfile);

--- a/config/gentoo
+++ b/config/gentoo
@@ -1,0 +1,60 @@
+#define ABEKASA60
+##define ABEKASA62	bug #455970
+#define ALIAS
+##define CGM
+#define CUBICOMP
+##define DVIRLE
+#define GRAYFILES
+#define MACPAINT
+##define PBMPLUS
+##define SUNRASTER
+#define TARGA
+#define VICAR
+#define WASATCH
+#define WAVEFRONT
+
+#define GCC
+
+#define CONST_DECL
+#define NO_MAKE_MAKEFILE
+#define USE_TIME_H
+#define SYS_V_SETPGRP
+#define USE_PROTOTYPES
+#define USE_RANDOM
+#define USE_STDARG
+#define USE_STDLIB_H
+#define USE_UNISTD_H
+#define USE_STRING_H
+#define VOID_STAR
+#define USE_XLIBINT_H
+#define X_SHARED_MEMORY
+
+#defpath DEST bin
+#defpath MAN_DEST man-dest
+#defpath RI include
+#defpath RL lib
+
+ROFF = nroff
+ROFFOPT = -man
+ROFFPIPE = | lpr
+
+INCTIFF = 
+LIBTIFF = -ltiff
+INCX11 =
+LIBX11 = -lX11
+
+# Most people have migrated X11 to /usr/lib, but just in case ...
+check_x11=$(shell \
+	echo 'int main(){}' > test.c ; \
+	if ! $(CC) test.c -lX11 -o .urt-x11-test 2>/dev/null ; then \
+		echo "-L/usr/X11R6/lib" ; \
+	fi ; \
+	rm -f .urt-x11-test test.c)
+LIBX11 += $(call check_x11)
+#define X11
+#define POSTSCRIPT
+#define TIFF
+ExtraCFLAGS = -march=native -O3 -pipe -fPIC -Wno-unused-result
+MFLAGS = -j4 -l4
+# prevent circular depend #111455
+#define GIF

--- a/get/getx11/XGetHClrs.c
+++ b/get/getx11/XGetHClrs.c
@@ -1,4 +1,4 @@
-#ifndef XLIBINT_H_NOT_AVAILABLE
+#ifdef XLIBINT_H_NOT_AVAILABLE
 
 /* $XConsortium: XGetHClrs.c,v 11.10 88/09/06 16:07:50 martin Exp $ */
 /* Copyright    Massachusetts Institute of Technology    1986	*/
@@ -23,12 +23,13 @@ static int dummy_handle_x_errors( dpy, event)
 }
 
 
-Status XAllocColors(dpy, cmap, defs, ndefs, statuses)
+Status XAllocColor(dpy, cmap, defs, ndefs, statuses)
 register Display *dpy;
 Colormap cmap;
 XColor *defs;
 int ndefs;
 Status *statuses;
+
 {
     xAllocColorReply rep;
     register xAllocColorReq *req;

--- a/get/getx11/getx11.c
+++ b/get/getx11/getx11.c
@@ -107,12 +107,12 @@ image_information *img_info = NULL;
 void init_img_info( i )
 image_information *i;
 {
-    i->window = i->icn_window = NULL;
-    i->pixmap = i->icn_pixmap = NULL;
-    i->pix_info_window = NULL;
+    i->window = i->icn_window = 0;
+    i->pixmap = i->icn_pixmap = 0;
+    i->pix_info_window = 0;
     i->gc = i->icn_gc = NULL;
     i->image = i->icn_image = NULL;
-    i->colormap = NULL;
+    i->colormap = 0;
     i->visual_class = -1;
     i->pixmap_failed = False;
 
@@ -1849,7 +1849,7 @@ Boolean flip_book;
 		}
 	    else handled_key = False;
 		
-	    DPRINTF(stderr, "%s %x, %s String '%s' - %d\n", symstr, keysym,
+	    DPRINTF(stderr, "%s %zx, %s String '%s' - %d\n", symstr, keysym,
 		    ( shifted_key )? "shifted":"unshifted", string, length );
 
 	    if ( !handled_key )

--- a/get/getx11/timer.c
+++ b/get/getx11/timer.c
@@ -72,8 +72,11 @@ void
 wait_timer()
 {
 #ifndef NO_ITIMER
+    sigset_t sig_alarm_mask;
+    (void) sigemptyset(&sig_alarm_mask);
+    (void) sigaddset(&sig_alarm_mask, SIGALRM);
     while (!ringring)
-	sigpause( ~sigmask(SIGALRM));
+	sigsuspend(&sig_alarm_mask);
     signal(SIGALRM, ofunc);
 #endif
 }

--- a/tools/avg4.c
+++ b/tools/avg4.c
@@ -34,7 +34,7 @@ static char rcs_ident[] = "$Header: /l/spencer/src/urt/tools/RCS/avg4.c,v 3.0.1.
 #include <stdio.h>
 #include "rle.h"
 
-static bit_count[16] = {0, 63, 63, 127, 63, 127, 127,
+static int bit_count[16] = {0, 63, 63, 127, 63, 127, 127,
     192, 63, 127, 127, 192, 127, 192, 192, 255};
 
 void

--- a/tools/mcut.c
+++ b/tools/mcut.c
@@ -791,7 +791,7 @@ rle_pixel **scan;
 		    TRACE( tmp_cb, cb_list )
 		    {
 			register color_t *newcol = &tmp_cb->color;
-			register newdist = DISTANCE( ref_col, *newcol );
+			register int newdist = DISTANCE( ref_col, *newcol );
 
 			if ( newdist < dist )
 			{
@@ -963,7 +963,7 @@ int
 cmp_radices ( h1, h2 )
 histogram_t **h1, **h2;
 {
-    register c1 = -1, c2 = -1;
+    register int c1 = -1, c2 = -1;
 
     if ( *h1 )
 	c1 = (*h1)->color & mask;

--- a/tools/rlehdr.c
+++ b/tools/rlehdr.c
@@ -290,7 +290,7 @@ char **comment_names;
 		{
 		    if ( (cp = index( the_comment, '\n' )) )
 			printf( ", %s=%.*s", *comment_names,
-				cp - the_comment - 1, the_comment );
+				(int)(cp - the_comment - 1), the_comment );
 		    else
 			printf( ", %s=%s", *comment_names, the_comment );
 		    break;


### PR DESCRIPTION
- Ignore build generated files of in source tree build.
- Replace xlib NULL pointers with integers fixing #3
- Suppress unused result warnings for config/gentoo only
- Fix singular/plural color variables and functions
- Fix typeless variables defaulting to int.